### PR TITLE
Release for v0.3.2

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,42 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.template (Optional)
+#       Pull request template in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+## [v0.3.2](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.3.1...v0.3.2) - 2023-07-29
+### 🏕 Features
+- Resolve #36, #37: Update `ALTER COLUMN` ASTs by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/38
+### 👒 Dependencies
+- Bump prettier from 2.8.8 to 3.0.0 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/35
+
+## [v0.3.1](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.3.0...v0.3.1) - 2023-07-10
+- Bump prettier from 2.8.7 to 2.8.8 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/25
+- Create github_pages.yml by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/27
+- Bump tree-sitter from 0.20.1 to 0.20.5 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/32
+- Support DIFFERENTIAL_PRICAY syntax by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/34
+
+## [v0.3.0](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.2.0...v0.3.0) - 2023-05-05
+- Bump prettier from 2.8.3 to 2.8.4 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/18
+- Bump prettier from 2.8.4 to 2.8.5 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/20
+- Bump prettier from 2.8.5 to 2.8.7 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/21
+- Bump tree-sitter-cli from 0.20.6 to 0.20.8 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/22
+
+## [v0.2.0](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.12...v0.2.0) - 2023-02-06
+- Bump prettier from 2.8.1 to 2.8.2 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/14
+- Bump prettier from 2.8.2 to 2.8.3 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/15
+- Support `HAVING MIN` and `HAVING MAX` syntax by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/17
+
+## [v0.1.12](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.11...v0.1.12) - 2022-12-29
+
+## [v0.1.11](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.10...v0.1.11) - 2022-12-29
+- Add package-release workflow by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/13
+
+## [v0.1.10](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.9...v0.1.10) - 2022-12-29
+
+## [v0.1.9](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.8...v0.1.9) - 2022-12-29
+- Bump prettier from 2.8.0 to 2.8.1 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/11
+- CHANGE: keyword argument syntax for function_call, call_statement by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/12
+
+## [v0.1.8](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.7...v0.1.8) - 2022-12-11
+
+## [v0.1.7](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.6...v0.1.7) - 2022-12-10
+
+## [v0.1.6](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.5...v0.1.6) - 2022-12-10
+- Bump prettier from 2.7.1 to 2.8.0 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/10
+
+## [v0.1.5](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.4...v0.1.5) - 2022-12-01
+
+## [v0.1.4](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.3...v0.1.4) - 2022-11-30
+
+## [v0.1.3](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.2...v0.1.3) - 2022-11-30
+
+## [v0.1.2](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.1...v0.1.2) - 2022-11-24
+
+## [v0.1.1](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.1.0...v0.1.1) - 2022-11-23
+
+## [v0.1.0](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.0.22...v0.1.0) - 2022-11-14
+- Bump prettier from 2.6.2 to 2.7.1 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/6
+- Bump tree-sitter-cli from 0.20.6 to 0.20.7 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/4
+- Bump nan from 2.15.0 to 2.17.0 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/5
+
+## [v0.0.22](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.0.21...v0.0.22) - 2022-10-18
+
+## [v0.0.21](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.0.20...v0.0.21) - 2022-09-19
+
+## [v0.0.20](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.0.19...v0.0.20) - 2022-09-19
+
+## [v0.0.19](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.0.18...v0.0.19) - 2022-09-19
+
+## [v0.0.18](https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.0.17...v0.0.18) - 2022-09-19

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-sql-bigquery",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "SQL grammar fom tree-sitter",
   "main": "bindings/node",
   "scripts": {


### PR DESCRIPTION
This pull request is for the next release as v0.3.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### 🏕 Features
* Resolve #36, #37: Update `ALTER COLUMN` ASTs by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/38
### 👒 Dependencies
* Bump prettier from 2.8.8 to 3.0.0 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/35


**Full Changelog**: https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.3.1...v0.3.2