### PR TITLE
v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tree-sitter-sql-bigquery"
 description = "BigQuery SQL grammar for the tree-sitter parsing library"
 authors = ["takegue <takegue@gmail.com>"]
-version = "0.6.0"
+version = "0.7.0"
 keywords = ["incremental", "parsing", "sql", "bigquery", "tree-sitter"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/takegue/tree-sitter-sql-bigquery"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.6.0
+VERSION := 0.7.0
 
 LANGUAGE_NAME := tree-sitter-sql_bigquery
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-sql-bigquery",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-sql-bigquery",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-sql-bigquery",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "SQL grammar fom tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-sql-bigquery"
 description = "SqlBigquery grammar for tree-sitter"
-version = "0.6.0"
+version = "0.7.0"
 keywords = ["incremental", "parsing", "tree-sitter", "sql-bigquery"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### 🏕 Features
* Support `AGGREGATION_THRESHOLD` clause by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/59
* Update support node version by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/78
* feat: migrate scanner from C++ to C and additional bindings of C, go, python, swift by @ilyakochik in https://github.com/takegue/tree-sitter-sql-bigquery/pull/75
* feat: Implementation RANGE function syntax by @takegue in https://github.com/takegue/tree-sitter-sql-bigquery/pull/82
### 👒 Dependencies
* Bump tree-sitter from 0.20.5 to 0.20.6 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/57
* Bump prettier from 3.0.3 to 3.2.5 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/65
* Bump peter-evans/create-pull-request from 4 to 6 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/92
* Bump actions/upload-pages-artifact from 1 to 3 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/91
* Bump actions/setup-node from 2 to 4 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/90
* Bump actions/checkout from 2 to 4 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/89
* Bump pkgdeps/git-tag-action from 2 to 3 by @dependabot in https://github.com/takegue/tree-sitter-sql-bigquery/pull/88

## New Contributors
* @ilyakochik made their first contribution in https://github.com/takegue/tree-sitter-sql-bigquery/pull/75

**Full Changelog**: https://github.com/takegue/tree-sitter-sql-bigquery/compare/v0.6.0...0.7.0